### PR TITLE
Remove UI unnecessary check

### DIFF
--- a/ScrumIt/Forms/AddSprint.cs
+++ b/ScrumIt/Forms/AddSprint.cs
@@ -46,16 +46,6 @@ namespace ScrumIt.Forms
                 MessageBox.Show(@"Sprint nie może być dłuższy niż 31 dni");
                 validationFlag = true;
             }
-            else
-            {
-                var endOfLastSprint = SprintModel.GetEndOfLastSprint(_projectId) ?? DateTime.Parse("1900-01-01");
-                if (startDate <= endOfLastSprint)
-                {
-                    MessageBox.Show(@"Data sprintu koliduje z innym sprintem");
-                    validationFlag = true;
-                }
-            }
-
 
             if (!validationFlag)
             {


### PR DESCRIPTION
Remove UI unnecessary check which caused that if there were a sprint created in far far future than in a free gap we we wouldn't be able to create new sprints